### PR TITLE
[Fix] DisposeResources: continue chain on throw

### DIFF
--- a/aos/AddDisposableResource.js
+++ b/aos/AddDisposableResource.js
@@ -29,7 +29,7 @@ module.exports = function AddDisposableResource(disposeCapability, V, hint) {
 
 	var resource;
 	if (arguments.length < 4) { // step 1
-		if (V == null && hint === 'SYNC_DISPOSE') {
+		if (V == null && hint === 'SYNC-DISPOSE') {
 			return 'UNUSED'; // step 1.a
 		}
 		resource = CreateDisposableResource(V, hint); // step 1.c

--- a/aos/DisposeResources.js
+++ b/aos/DisposeResources.js
@@ -11,7 +11,6 @@ var $then = callBound('Promise.prototype.then', true);
 
 var CompletionRecord = require('es-abstract/2025/CompletionRecord');
 var Dispose = require('./Dispose');
-var NormalCompletion = require('es-abstract/2025/NormalCompletion');
 var PromiseResolve = require('es-abstract/2025/PromiseResolve');
 var ThrowCompletion = require('es-abstract/2025/ThrowCompletion');
 
@@ -56,9 +55,8 @@ module.exports = function DisposeResources(disposeCapability, completion) {
 	};
 
 	var getPromise = actualHint === 'ASYNC-DISPOSE' && function getPromise(resource) {
-		return $then(
-			promise,
-			function () {
+		var runDispose = function () {
+			try {
 				var result = Dispose( // step 2.a
 					resource['[[ResourceValue]]'],
 					resource['[[Hint]]'],
@@ -67,9 +65,19 @@ module.exports = function DisposeResources(disposeCapability, completion) {
 				if (!result) {
 					throw new $SyntaxError('Assertion failed: non-`~ASYNC-DISPOSE~` resource returned a promise from Dispose');
 				}
-				return $then(result, NormalCompletion);
-			},
-			rejecter
+				return $then(result, void undefined, rejecter);
+			} catch (e) {
+				rejecter(e);
+			}
+			return void undefined;
+		};
+		return $then(
+			promise,
+			runDispose,
+			function (e) {
+				rejecter(e);
+				return runDispose();
+			}
 		);
 	};
 
@@ -96,5 +104,10 @@ module.exports = function DisposeResources(disposeCapability, completion) {
 	// eslint-disable-next-line no-param-reassign
 	disposeCapability['[[DisposableResourceStack]]'] = null; // step 3
 
-	return actualHint === 'ASYNC-DISPOSE' ? promise : completion; // step 4
+	if (actualHint === 'ASYNC-DISPOSE') { // step 4
+		return $then(promise, function () {
+			return completion;
+		});
+	}
+	return completion;
 };

--- a/test/tests.js
+++ b/test/tests.js
@@ -13,6 +13,7 @@ var semver = require('semver');
 var gOPD = require('gopd');
 var defineAccessorProperty = require('define-accessor-property');
 var SuppressedError = require('suppressed-error/polyfill')();
+var SLOT = require('internal-slot');
 
 var brokenNodePolyfill = semver.satisfies(process.version, '^18.18 || >= 20.4');
 
@@ -98,6 +99,12 @@ module.exports = {
 			instance.use(null);
 			instance.use();
 			instance.use(disposable);
+
+			// AddDisposableResource step 1.a: `use(null)` and `use(undefined)` on a sync stack must return without pushing a resource.
+			if (SLOT.has(instance, '[[DisposeCapability]]')) {
+				var cap = SLOT.get(instance, '[[DisposeCapability]]');
+				st.equal(cap['[[DisposableResourceStack]]'].length, 2, '`use(null)` and `use(undefined)` do not add a resource');
+			}
 
 			forEach(v.nonNullPrimitives, function (nonNullishObject) {
 				st['throws'](

--- a/test/tests.js
+++ b/test/tests.js
@@ -621,7 +621,35 @@ module.exports = {
 					function (e) {
 						st.equal(e, throwSentinel, 'throws `throwSentinel`');
 					}
-				);
+				).then(function () {
+					// https://github.com/es-shims/DisposableStack/issues/9
+					var instance3 = new AsyncDisposableStack();
+					var ran = 0;
+					instance3.defer(function () { ran += 1; });
+					instance3.defer(throwsSentinel);
+
+					return instance3.disposeAsync().then(
+						function () {
+							st.fail('dispose with a throwing later disposable failed to throw');
+						},
+						function (e) {
+							st.equal(e, throwSentinel, 'throws `throwSentinel` when an earlier-pushed defer throws');
+							st.equal(ran, 1, 'later-pushed non-throwing defer still ran');
+						}
+					);
+				}).then(function () {
+					var instance4 = new AsyncDisposableStack();
+					instance4.defer(function () { return Promise.reject(throwSentinel); });
+
+					return instance4.disposeAsync().then(
+						function () {
+							st.fail('dispose with a rejecting disposable failed to throw');
+						},
+						function (e) {
+							st.equal(e, throwSentinel, 'rejecting defer surfaces `throwSentinel`');
+						}
+					);
+				});
 			});
 		});
 


### PR DESCRIPTION
Fixes https://github.com/es-shims/DisposableStack/issues/9.

## Root cause

In `aos/DisposeResources.js`, the async path chained each resource's disposal via `$then(prev, onFulfilled, rejecter)`. Two problems:

1. When one resource's dispose rejected, the next iteration only installed `rejecter` on the rejected promise, so the earlier-pushed resource's dispose never ran.
2. `rejecter` returned `undefined`, so the final promise resolved to `undefined` instead of the accumulated `CompletionRecord`. The caller's `completion['?']()` then threw the TypeError shown above.

## Changes

- **`aos/DisposeResources.js`**: rewrite the async path so every resource's dispose runs regardless of earlier errors, and the promise resolves to the up-to-date completion at the end.
- **`aos/AddDisposableResource.js`**: fix a typo (`'SYNC_DISPOSE'` -> `'SYNC-DISPOSE'`) so `use(null)` / `use(undefined)` on a sync `DisposableStack` correctly returns `UNUSED` (step 1.a) instead of pushing a method-less sync resource. Lands in its own commit with a regression test.
- **`test/tests.js`**: regression tests for the issue (a throwing later-pushed defer runs the earlier-pushed defer, and a promise-rejecting defer surfaces the rejection) and for the `SYNC-DISPOSE` typo.

The existing behavior of rejecting mixed sync/async stacks is unchanged.

## Test plan

- [x] `npm test` (runs lint + 822 tape assertions, 812 pre-existing + 10 new) passes.
- [x] Manual repro from the issue behaves as expected (`1` is printed, then `Error: 2` is thrown):

```
~/DisposableStack % cat test.mjs
import './auto.js';

async function main() {
    await using stack = new AsyncDisposableStack()    
    
    stack.defer(() => {
        console.log('1')
    })
    
    stack.defer(() => {
        throw new Error('2')
    })
}

void main()

~/DisposableStack % node test.mjs
1
file:///~/DisposableStack/test.mjs:11
        throw new Error('2')
              ^

Error: 2
    at file:///~/DisposableStack/test.mjs:11:15
    at AsyncDisposableStack.disposeAsync (<anonymous>)
    at main (file:///~/DisposableStack/test.mjs:10:11)
    at file:///~/DisposableStack/test.mjs:15:6
    at ModuleJob.run (node:internal/modules/esm/module_job:430:25)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:661:26)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5)

Node.js v24.14.1
```